### PR TITLE
Add voice assistant framework and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+SCRYPTED_URL=https://scrypted.example
+SCRYPTED_TOKEN=changeme
+WAKEWORD=hey_nova
+VOICE=en_US
+USE_PUSH_TO_TALK=false
+PTT_KEY=F9

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# Aquarium-Blender-Add-on
-Blender add-on and script for optimizing 3D models for aquarium-safe printing on the Bambu Lab X1C. Adds vent holes, base ring, solidifies walls, and exports ready-to-print STLs. Ideal for PETG/PLA prints that sink and stay put.
+# AI Assistant
+
+Voice controlled assistant integrating Scrypted cameras, Ollama LLM/VLM and
+Coqui/Piper TTS.
+
+## Setup
+
+1. Create and activate a conda environment named `ai-assistant`.
+2. `pip install -r requirements.txt`
+3. Install a compatible NVIDIA GPU driver.
+4. Install [Ollama](https://ollama.ai) and run `scripts/install_ollama_models.ps1`
+   to pull the required models (`llama3.1` and `llava`).
+5. Copy `.env.example` to `.env` and fill in your `SCRYPTED_URL` and
+   `SCRYPTED_TOKEN`.
+
+## Development
+
+Run the assistant in development mode:
+
+```powershell
+./scripts/run_dev.ps1
+```
+
+## Testing
+
+Run unit tests with:
+
+```bash
+pytest
+```
+
+## Troubleshooting
+
+- Ensure CUDA is correctly installed and accessible.
+- Check audio device permissions if recording or playback fails.
+- Verify Scrypted URL/token and network connectivity.

--- a/assistant/__init__.py
+++ b/assistant/__init__.py
@@ -1,0 +1,1 @@
+"""Voice assistant package."""

--- a/assistant/audio_io.py
+++ b/assistant/audio_io.py
@@ -1,0 +1,74 @@
+"""Audio input/output utilities using :mod:`sounddevice`.
+
+The module exposes a non-blocking microphone stream and convenience
+functions for recording audio to a temporary WAV file and playing WAV
+files.
+"""
+from __future__ import annotations
+
+import queue
+import tempfile
+import wave
+from pathlib import Path
+from typing import Generator
+
+import numpy as np
+import sounddevice as sd
+
+# ---------------------------------------------------------------------------
+# Streaming microphone input
+
+
+def microphone_stream(
+    samplerate: int = 16_000, channels: int = 1
+) -> tuple[sd.InputStream, "queue.Queue[np.ndarray]"]:
+    """Return a started :class:`~sounddevice.InputStream` and a queue.
+
+    Audio chunks are put into the queue as numpy arrays.  The caller is
+    responsible for stopping and closing the stream.
+    """
+
+    q: "queue.Queue[np.ndarray]" = queue.Queue()
+
+    def _callback(indata, frames, time, status):
+        if status:
+            print("InputStream status:", status)
+        q.put(indata.copy())
+
+    stream = sd.InputStream(
+        samplerate=samplerate, channels=channels, callback=_callback
+    )
+    stream.start()
+    return stream, q
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers
+
+
+def record_seconds(
+    seconds: float = 4.0, samplerate: int = 16_000, channels: int = 1
+) -> str:
+    """Record audio for ``seconds`` and return path to a temporary WAV file."""
+    frames = int(seconds * samplerate)
+    data = sd.rec(frames, samplerate=samplerate, channels=channels)
+    sd.wait()
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as f:
+        path = Path(f.name)
+
+    # Write WAV file using 16‑bit PCM
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(2)  # 16-bit
+        wf.setframerate(samplerate)
+        wf.writeframes((data * 32767).astype(np.int16).tobytes())
+    return str(path)
+
+
+def play_wav(path: str) -> None:
+    """Play a WAV file located at ``path``."""
+    with wave.open(path, "rb") as wf:
+        data = wf.readframes(wf.getnframes())
+        sd.play(np.frombuffer(data, dtype=np.int16), wf.getframerate())
+        sd.wait()

--- a/assistant/brain.py
+++ b/assistant/brain.py
@@ -1,0 +1,40 @@
+"""Main orchestration logic tying all components together."""
+from __future__ import annotations
+
+import logging
+
+from . import audio_io, intents, stt, tts, wake
+
+logger = logging.getLogger(__name__)
+
+last_transcript: str | None = None
+last_response: str | None = None
+
+
+class Brain:
+    """Runs the assistant interaction loop."""
+
+    def __init__(self, stt_model: str = "medium.en") -> None:
+        self.stt_model = stt_model
+
+    def run_once(self) -> None:
+        global last_transcript, last_response
+        wake.listen_for_wake()
+        wav = audio_io.record_seconds()
+        logger.info("recorded audio at %s", wav)
+        last_transcript = stt.transcribe(wav, self.stt_model)
+        logger.info("transcript: %s", last_transcript)
+        last_response = intents.handle_command(last_transcript)
+        logger.info("response: %s", last_response)
+        tts.speak(last_response)
+
+    def run(self) -> None:
+        while True:
+            try:
+                self.run_once()
+            except Exception as exc:  # pragma: no cover - safety net
+                logger.exception("Error in interaction loop: %s", exc)
+                try:
+                    tts.speak("Sorry, something went wrong")
+                except Exception:
+                    pass

--- a/assistant/config.py
+++ b/assistant/config.py
@@ -1,0 +1,30 @@
+"""Configuration handling for the assistant.
+
+Loads environment variables from a ``.env`` file using
+:mod:`python-dotenv`.
+"""
+from __future__ import annotations
+
+import os
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
+# --- Required configuration -------------------------------------------------
+SCRYPTED_URL: str | None = os.getenv("SCRYPTED_URL")
+SCRYPTED_TOKEN: str | None = os.getenv("SCRYPTED_TOKEN")
+
+# --- Optional configuration -------------------------------------------------
+WAKEWORD: str = os.getenv("WAKEWORD", "hey_nova")
+VOICE: str = os.getenv("VOICE", "en_US")
+
+# Device ID mapping used by :mod:`intents` to resolve rooms to cameras.
+# Users should edit their ``.env`` or modify this dictionary at runtime.
+DEVICE_IDS: dict[str, str] = {}
+
+# Flags controlling push-to-talk behaviour
+USE_PUSH_TO_TALK: bool = os.getenv("USE_PUSH_TO_TALK", "false").lower() in {
+    "1", "true", "yes"
+}
+PTT_KEY: str = os.getenv("PTT_KEY", "F9")

--- a/assistant/intents.py
+++ b/assistant/intents.py
@@ -1,0 +1,52 @@
+"""Simple intent routing for natural language commands."""
+from __future__ import annotations
+
+import re
+
+from . import config, llm, scrypted, vlm
+
+
+def _resolve(room: str) -> str | None:
+    return config.DEVICE_IDS.get(room.lower())
+
+
+def handle_command(text: str) -> str:
+    """Route ``text`` to the appropriate handler."""
+    text_low = text.lower()
+    m = re.search(r"describe (.+?) camera", text_low)
+    if m:
+        room = m.group(1).strip()
+        device_id = _resolve(room)
+        if not device_id:
+            return f"Unknown device for {room}"
+        image = scrypted.snapshot(device_id)
+        return vlm.analyze_image(f"Describe the {room} camera", image)
+
+    m = re.search(r"arm (.+?) camera", text_low)
+    if m:
+        room = m.group(1).strip()
+        device_id = _resolve(room)
+        if not device_id:
+            return f"Unknown device for {room}"
+        return "Armed" if scrypted.arm(device_id) else "Unable to arm"
+
+    return llm.chat(text)
+
+
+def handle_tool(block: dict) -> str:
+    """Handle JSON tool calls emitted by the LLM."""
+    tool = block.get("tool")
+    args = block.get("args", {})
+    if tool == "scrypted.snapshot":
+        device_id = args.get("device_id")
+        if not device_id:
+            return "device_id missing"
+        image = scrypted.snapshot(device_id)
+        prompt = args.get("prompt", "Describe the snapshot")
+        return vlm.analyze_image(prompt, image)
+    if tool == "scrypted.arm":
+        device_id = args.get("device_id")
+        if not device_id:
+            return "device_id missing"
+        return "Armed" if scrypted.arm(device_id) else "Unable to arm"
+    return "Unknown tool"

--- a/assistant/llm.py
+++ b/assistant/llm.py
@@ -1,0 +1,37 @@
+"""Interface to a local Ollama large language model."""
+from __future__ import annotations
+
+import json
+import requests
+
+OLLAMA_URL = "http://localhost:11434"
+
+
+def _route_tool(block: dict) -> str:
+    """Delegate tool invocation to :mod:`intents`."""
+    from . import intents
+
+    return intents.handle_tool(block)
+
+
+def chat(prompt: str, system: str | None = None) -> str:
+    """Send ``prompt`` to the LLM and return its textual response.
+
+    If the model returns a JSON object with ``tool`` and ``args`` fields
+    it is interpreted as a function call and routed to
+    :func:`intents.handle_tool`.
+    """
+
+    payload: dict[str, object] = {"model": "llama3.1", "prompt": prompt}
+    if system:
+        payload["system"] = system
+    resp = requests.post(f"{OLLAMA_URL}/api/generate", json=payload, timeout=120)
+    resp.raise_for_status()
+    text = resp.json().get("response", "")
+    try:
+        block = json.loads(text)
+    except json.JSONDecodeError:
+        return text
+    if isinstance(block, dict) and "tool" in block:
+        return _route_tool(block)
+    return text

--- a/assistant/main.py
+++ b/assistant/main.py
@@ -1,0 +1,40 @@
+"""Entry point for running the assistant."""
+from __future__ import annotations
+
+import argparse
+import logging
+import threading
+
+import uvicorn
+
+from . import brain as brain_module, config, web
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--no-wake", action="store_true", help="PTT only")
+    parser.add_argument("--stt-model", default="medium.en")
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args()
+
+    if args.quiet:
+        logging.basicConfig(level=logging.ERROR)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    if args.no_wake:
+        config.USE_PUSH_TO_TALK = True
+
+    brain = brain_module.Brain(stt_model=args.stt_model)
+
+    def _run_app():
+        uvicorn.run(web.app, host="0.0.0.0", port=8000, log_level="warning")
+
+    t = threading.Thread(target=_run_app, daemon=True)
+    t.start()
+
+    brain.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/assistant/scrypted.py
+++ b/assistant/scrypted.py
@@ -1,0 +1,42 @@
+"""Helpers for interacting with the Scrypted REST API."""
+from __future__ import annotations
+
+import requests
+
+from . import config
+
+
+def _headers() -> dict[str, str]:
+    if not config.SCRYPTED_TOKEN:
+        raise RuntimeError("SCRYPTED_TOKEN is not configured")
+    return {"Authorization": f"Bearer {config.SCRYPTED_TOKEN}"}
+
+
+def list_devices() -> list[dict]:
+    resp = requests.get(f"{config.SCRYPTED_URL}/api/devices", headers=_headers())
+    resp.raise_for_status()
+    return resp.json()
+
+
+def snapshot(device_id: str) -> bytes:
+    resp = requests.get(
+        f"{config.SCRYPTED_URL}/api/devices/{device_id}/snapshot",
+        headers=_headers(),
+    )
+    resp.raise_for_status()
+    return resp.content
+
+
+def arm(device_id: str) -> bool:
+    """Attempt to arm the specified device.
+
+    Some devices may not support this feature.  The function returns
+    ``False`` if the endpoint is not found (HTTP 404).
+    """
+
+    url = f"{config.SCRYPTED_URL}/api/devices/{device_id}/arm"
+    resp = requests.post(url, headers=_headers())
+    if resp.status_code == 404:
+        return False
+    resp.raise_for_status()
+    return True

--- a/assistant/stt.py
+++ b/assistant/stt.py
@@ -1,0 +1,18 @@
+"""Speech-to-text utilities using :mod:`faster_whisper`."""
+from __future__ import annotations
+
+from functools import lru_cache
+
+from faster_whisper import WhisperModel
+
+
+@lru_cache(maxsize=2)
+def _get_model(model_size: str) -> WhisperModel:
+    return WhisperModel(model_size, device="cuda", compute_type="float16")
+
+
+def transcribe(wav_path: str, model_size: str = "medium.en") -> str:
+    """Transcribe ``wav_path`` and return the recognised text."""
+    model = _get_model(model_size)
+    segments, _info = model.transcribe(wav_path)
+    return " ".join(seg.text.strip() for seg in segments)

--- a/assistant/tts.py
+++ b/assistant/tts.py
@@ -1,0 +1,30 @@
+"""Text-to-speech helpers."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from . import audio_io
+
+
+def _run_cmd(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def speak(text: str) -> Path:
+    """Speak ``text`` using an available CLI TTS engine.
+
+    The generated audio is written to ``reply.wav`` in the current
+    working directory and then played back.  The path is returned.
+    """
+
+    out = Path("reply.wav")
+    if shutil.which("tts"):
+        _run_cmd(["tts", "--text", text, "--out_path", str(out)])
+    elif shutil.which("piper"):
+        _run_cmd(["piper", "--text", text, "--output_file", str(out)])
+    else:  # pragma: no cover - depends on external software
+        raise RuntimeError("No TTS engine available")
+    audio_io.play_wav(str(out))
+    return out

--- a/assistant/vlm.py
+++ b/assistant/vlm.py
@@ -1,0 +1,25 @@
+"""Vision-language model helpers using Ollama's ``llava`` model."""
+from __future__ import annotations
+
+import base64
+import requests
+
+from .llm import OLLAMA_URL
+
+
+def analyze_image(prompt: str, image_bytes: bytes) -> str:
+    """Return a short description and safety summary for ``image_bytes``."""
+    b64 = base64.b64encode(image_bytes).decode("ascii")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {"type": "image", "image": b64},
+            ],
+        }
+    ]
+    payload = {"model": "llava", "messages": messages}
+    resp = requests.post(f"{OLLAMA_URL}/api/chat", json=payload, timeout=120)
+    resp.raise_for_status()
+    return resp.json().get("message", {}).get("content", "")

--- a/assistant/wake.py
+++ b/assistant/wake.py
@@ -1,0 +1,52 @@
+"""Wake-word and push-to-talk handling."""
+from __future__ import annotations
+
+import time
+import keyboard
+
+from . import audio_io, config
+
+try:  # openwakeword may not be installed on all systems
+    import openwakeword
+except Exception:  # pragma: no cover - only triggered when lib missing
+    openwakeword = None
+
+
+_LAST_TRIGGER = 0.0
+
+
+def listen_for_wake(threshold: float = 0.75) -> str:
+    """Block until the wake word or push-to-talk key is detected.
+
+    Returns ``"wakeword"`` or ``"push_to_talk"`` depending on what fired.
+    A simple debounce prevents rapid re-triggering.
+    """
+
+    global _LAST_TRIGGER
+
+    if config.USE_PUSH_TO_TALK:
+        keyboard.wait(config.PTT_KEY)
+        _LAST_TRIGGER = time.time()
+        return "push_to_talk"
+
+    if openwakeword is None:
+        raise RuntimeError("openwakeword not available")
+
+    model = openwakeword.Model(wakewords=[config.WAKEWORD])
+    stream, q = audio_io.microphone_stream()
+
+    try:
+        while True:
+            data = q.get()
+            scores = model.predict(data)
+            score = scores.get(config.WAKEWORD, 0.0)
+            now = time.time()
+            if score > threshold and now - _LAST_TRIGGER > 1.0:
+                _LAST_TRIGGER = now
+                return "wakeword"
+            if keyboard.is_pressed(config.PTT_KEY) and now - _LAST_TRIGGER > 1.0:
+                _LAST_TRIGGER = now
+                return "push_to_talk"
+    finally:
+        stream.stop()
+        stream.close()

--- a/assistant/web.py
+++ b/assistant/web.py
@@ -1,0 +1,56 @@
+"""FastAPI application exposing simple health/status endpoints."""
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+from fastapi import FastAPI
+
+from . import brain, tts
+
+app = FastAPI()
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/status")
+async def status() -> dict[str, Any]:
+    """Return last transcript/response and GPU memory usage if available."""
+    try:
+        mem = (
+            subprocess.check_output(
+                [
+                    "nvidia-smi",
+                    "--query-gpu=memory.used",
+                    "--format=csv,noheader,nounits",
+                ]
+            )
+            .decode()
+            .strip()
+        )
+    except Exception:
+        mem = "unknown"
+    return {
+        "last_transcript": brain.last_transcript,
+        "last_response": brain.last_response,
+        "gpu_mem": mem,
+    }
+
+
+@app.post("/say")
+async def say(text: str) -> dict[str, str]:
+    tts.speak(text)
+    return {"status": "ok"}
+
+
+@app.get("/")
+async def index() -> str:
+    return (
+        "<html><body><h1>Assistant</h1>"
+        f"<p>Last transcript: {brain.last_transcript}</p>"
+        f"<p>Last response: {brain.last_response}</p>"
+        "</body></html>"
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+python-dotenv==1.0.1
+sounddevice==0.4.6
+numpy==1.24.4
+openwakeword==0.6.0
+faster-whisper==0.10.0
+TTS==0.22.0
+requests==2.32.3
+keyboard==0.13.5
+fastapi==0.110.2
+uvicorn==0.30.1
+pytest==8.1.1

--- a/scripts/install_ollama_models.ps1
+++ b/scripts/install_ollama_models.ps1
@@ -1,0 +1,10 @@
+# Ensure the Ollama service is reachable and pull required models
+try {
+    curl http://localhost:11434/api/version | Out-Null
+} catch {
+    Write-Host "Ollama service not running" -ForegroundColor Red
+    exit 1
+}
+
+ollama pull llama3.1
+ollama pull llava

--- a/scripts/run_dev.ps1
+++ b/scripts/run_dev.ps1
@@ -1,0 +1,4 @@
+# Activate conda environment and run the assistant in development mode
+param([string]$Args="")
+conda activate ai-assistant
+python -m assistant.main $Args

--- a/tests/test_audio_loop.py
+++ b/tests/test_audio_loop.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import numpy as np
+import sounddevice as sd
+
+from assistant import audio_io
+
+
+def test_record_play(monkeypatch, tmp_path):
+    frames = []
+
+    def fake_rec(n_frames, samplerate, channels):
+        frames.append(n_frames)
+        return np.zeros((n_frames, channels), dtype=np.float32)
+
+    def fake_play(data, rate):
+        assert data.size > 0
+
+    monkeypatch.setattr(sd, "rec", fake_rec)
+    monkeypatch.setattr(sd, "play", fake_play)
+    monkeypatch.setattr(sd, "wait", lambda: None)
+
+    path = audio_io.record_seconds(0.1, samplerate=8000)
+    assert frames[0] == 800
+    audio_io.play_wav(path)

--- a/tests/test_llm_vlm.py
+++ b/tests/test_llm_vlm.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import base64
+import json
+
+import requests
+
+from assistant import llm, vlm
+
+
+def test_llm_request(monkeypatch):
+    sent = {}
+
+    class Resp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    def fake_post(url, json=None, timeout=0):  # noqa: A003 - shadow builtin
+        sent["url"] = url
+        sent["json"] = json
+        return Resp({"response": "hello"})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    out = llm.chat("hi")
+    assert out == "hello"
+    assert sent["url"].endswith("/api/generate")
+    assert sent["json"]["model"] == "llama3.1"
+
+
+def test_vlm_request(monkeypatch):
+    sent = {}
+
+    class Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"message": {"content": "ok"}}
+
+    def fake_post(url, json=None, timeout=0):  # noqa: A003
+        sent["url"] = url
+        sent["json"] = json
+        return Resp()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    result = vlm.analyze_image("prompt", b"bytes")
+    assert result == "ok"
+    assert sent["url"].endswith("/api/chat")
+    assert sent["json"]["model"] == "llava"
+    img_b64 = sent["json"]["messages"][0]["content"][1]["image"]
+    assert base64.b64decode(img_b64) == b"bytes"

--- a/tests/test_scrypted_api.py
+++ b/tests/test_scrypted_api.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import requests
+
+from assistant import scrypted
+
+
+def test_headers_and_urls(monkeypatch):
+    scrypted.config.SCRYPTED_URL = "http://host"
+    scrypted.config.SCRYPTED_TOKEN = "token"
+
+    calls = []
+
+    class Resp:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+        @property
+        def content(self):
+            return b"data"
+
+    def fake_get(url, headers):
+        calls.append((url, headers))
+        return Resp()
+
+    def fake_post(url, headers):
+        calls.append((url, headers))
+        return Resp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    scrypted.list_devices()
+    scrypted.snapshot("dev")
+    scrypted.arm("dev")
+
+    assert calls[0][0] == "http://host/api/devices"
+    for _url, headers in calls:
+        assert headers["Authorization"] == "Bearer token"


### PR DESCRIPTION
## Summary
- Implement configurable voice assistant modules (audio, wakeword, STT/TTS, LLM/VLM, Scrypted API, intents, web interface and CLI).
- Provide PowerShell scripts and README for setup and development.
- Add unit tests for audio loop, Scrypted API calls, and Ollama integration.

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bd8f2caa883299bbb7968d9ecaf2f